### PR TITLE
Improve versatility of HTTP requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,4 @@ typings/
 # next.js build output
 .next
 
-package-lock.json
-
 dist

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are the following options:
 - `auth` Pi-hole auth token.
 - `host` Pi-hole host, default is `localhost`.
 - `port` Pi-hole port, default is `80`.
+- `ssl` If the Pi-hole server should be connected to with SSL.
 - `baseDirectory` the directory where Pi-hole is found on the server, default is `/admin/`
 - `time` How long Pi-hole will be disabled, in seconds, default is 0 that means permanently disabled.
 - `logLevel` Logging level, three different levels: 0: logging disabled, 1: logs only HTTP errors, 2: logs each HTTP response. Default is set to 1.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are the following options:
 - `auth` Pi-hole auth token.
 - `host` Pi-hole host, default is `localhost`.
 - `port` Pi-hole port, default is `80`.
+- `baseDirectory` the directory where Pi-hole is found on the server, default is `/admin/`
 - `time` How long Pi-hole will be disabled, in seconds, default is 0 that means permanently disabled.
 - `logLevel` Logging level, three different levels: 0: logging disabled, 1: logs only HTTP errors, 2: logs each HTTP response. Default is set to 1.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,6 +33,14 @@
                 "required": false,
                 "description": "Pi-hole port, default is 80."
             },
+            "baseDirectory": {
+                "title": "Base Directory",
+                "type": "string",
+                "placeholder": "/admin/",
+                "default": "/admin/",
+                "required": false,
+                "description": "The directory where the pi-hole configuration pages are located with slashes.  Typically /admin/."
+            },
             "time": {
                 "title": "Time",
                 "type": "integer",

--- a/config.schema.json
+++ b/config.schema.json
@@ -17,6 +17,13 @@
                 "required": false,
                 "description": "Pi-hole auth token."
             },
+            "ssl": {
+                "title": "SSL",
+                "type": "boolean",
+                "default": false,
+                "required": false,
+                "description": "If the Pi-hole server should be connected to with HTTPS."
+            },
             "host": {
                 "title": "Host",
                 "type": "string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,6 +212,11 @@
       "integrity": "sha512-dClwnyfRd3BZxu3KAdhvAayozq7fLazXGlDc4HAHJV1M+olqGKAT52pygXQu5UiDSHxz/WB3KRvsojqQ5zmXOA==",
       "dev": true
     },
+    "flatted": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.0.2.tgz",
+      "integrity": "sha512-CsGzkXnjwEGEetj4HLWbjePVyal4AzgfjrP3FaLqPg30uZ8LyNKrTU4gciZc9g0xWArqbmObTjSLQ1QOF6u2Wg=="
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,11 +212,6 @@
       "integrity": "sha512-dClwnyfRd3BZxu3KAdhvAayozq7fLazXGlDc4HAHJV1M+olqGKAT52pygXQu5UiDSHxz/WB3KRvsojqQ5zmXOA==",
       "dev": true
     },
-    "flatted": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.0.2.tgz",
-      "integrity": "sha512-CsGzkXnjwEGEetj4HLWbjePVyal4AzgfjrP3FaLqPg30uZ8LyNKrTU4gciZc9g0xWArqbmObTjSLQ1QOF6u2Wg=="
-    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,666 @@
+{
+  "name": "homebridge-pihole",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
+      "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "bonjour-hap": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.5.10.tgz",
+      "integrity": "sha512-vaqa4uUST8K5rj9QGe6GaSJ+6rQ24KzgkjdyZvoTpbKBti5xL/m8H9Dp9VmPdo434OAetqU5PKAn5izucrKEBA==",
+      "dev": true,
+      "requires": {
+        "array-flatten": "^2.1.2",
+        "deep-equal": "^2.0.2",
+        "ip": "^1.1.5",
+        "multicast-dns": "^7.2.2",
+        "multicast-dns-service-types": "^1.1.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
+      "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "dns-packet": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "fast-srp-hap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.1.tgz",
+      "integrity": "sha512-dClwnyfRd3BZxu3KAdhvAayozq7fLazXGlDc4HAHJV1M+olqGKAT52pygXQu5UiDSHxz/WB3KRvsojqQ5zmXOA==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "futoin-hkdf": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.3.2.tgz",
+      "integrity": "sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw==",
+      "dev": true
+    },
+    "hap-nodejs": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.7.3.tgz",
+      "integrity": "sha512-kCPwdRizCPJk43eTSMtW2LtCh+it8rTYW7aGkhW8qFKPS4z5JQilpggvVJvdfmSy5l+L5F0/UyKwkeM/KsdrHA==",
+      "dev": true,
+      "requires": {
+        "bonjour-hap": "~3.5.8",
+        "debug": "^4.1.1",
+        "decimal.js": "^10.2.0",
+        "fast-srp-hap": "2.0.1",
+        "futoin-hkdf": "~1.3.2",
+        "ip": "^1.1.3",
+        "node-persist": "^0.0.11",
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "homebridge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.1.0.tgz",
+      "integrity": "sha512-OMs+1A2G6lkMOrAk0o1nmj8S3XkhwrInVwRDiyLB3aHRQS02KQ/Egv1stV9vDhjib86v3y3MLHIYYzbxKHLjPA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "commander": "5.0.0",
+        "hap-nodejs": "^0.7.3",
+        "node-persist": "^0.0.11",
+        "qrcode-terminal": "^0.12.0",
+        "semver": "^7.3.2",
+        "source-map-support": "^0.5.19"
+      }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g==",
+      "dev": true
+    },
+    "is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "multicast-dns": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
+      "integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
+      "dev": true,
+      "requires": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "node-persist": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.11.tgz",
+      "integrity": "sha1-1m66Pr72IPB5Uw+nsTB2qQZmWHQ=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "q": "~1.1.1"
+      }
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "q": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+      "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok=",
+      "dev": true
+    },
+    "qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "dev": true
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
+      "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "object-inspect": "^1.7.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
+      "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/arendruni/homebridge-pihole#readme",
   "dependencies": {
-    "axios": "^0.19.2"
+    "axios": "^0.19.2",
+    "flatted": "^3.0.2"
   },
   "engines": {
     "homebridge": ">=0.2.0"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://github.com/arendruni/homebridge-pihole#readme",
   "dependencies": {
-    "axios": "^0.19.2",
-    "flatted": "^3.0.2"
+    "axios": "^0.19.2"
   },
   "engines": {
     "homebridge": ">=0.2.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "url": "https://github.com/arendruni/homebridge-pihole/issues"
   },
   "homepage": "https://github.com/arendruni/homebridge-pihole#readme",
-  "dependencies": {},
+  "dependencies": {
+    "axios": "^0.19.2"
+  },
   "engines": {
     "homebridge": ">=0.2.0"
   },

--- a/sample-config.json
+++ b/sample-config.json
@@ -12,6 +12,7 @@
 			"accessory": "Pihole",
 			"name": "Homelab pi-hole - 2 minutes",
 			"auth": "3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0",
+			"ssl": false,
 			"host": "192.168.1.2",
 			"baseDirectory": "/myPiHoleConfig/",
 			"time": 120

--- a/sample-config.json
+++ b/sample-config.json
@@ -13,6 +13,7 @@
 			"name": "Homelab pi-hole - 2 minutes",
 			"auth": "3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0",
 			"host": "192.168.1.2",
+			"baseDirectory": "/myPiHoleConfig/",
 			"time": 120
 		}
 	]

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export = (api: API) => {
 	api.registerAccessory("homebridge-pihole", "Pihole", PiholeSwitch);
 };
 
-const BASE_URL = "/admin/api.php",
+const BASE_URL = "api.php",
 	STATUS_URL = "status",
 	ENABLE_URL = "enable",
 	DISABLE_URL = "disable",
@@ -37,6 +37,7 @@ class PiholeSwitch implements AccessoryPlugin {
 
 	private auth: string;
 	private host: string;
+	private baseDirectory: string;
 	private time: number;
 	private port: number;
 	private logLevel: number;
@@ -54,6 +55,7 @@ class PiholeSwitch implements AccessoryPlugin {
 
 		this.auth = config["auth"] || "";
 		this.host = config["host"] || "localhost";
+		this.baseDirectory = config["baseDirectory"] || "/admin/";
 		this.time = config["time"] || 0;
 		this.port = config["port"] || 80;
 		this.logLevel = config["logLevel"] || 1;
@@ -125,7 +127,7 @@ class PiholeSwitch implements AccessoryPlugin {
 		let request = http.get({
 			host: this.host,
 			port: this.port,
-			path: `${BASE_URL}?${path}`
+			path: `${this.baseDirectory}${BASE_URL}?${path}`
 		}, (response) => this._responseHandler(response, next));
 
 		request.on("error", (error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "homebridge";
 
 import axios, { AxiosResponse } from "axios";
+import { stringify } from "flatted";
 import {
 	LogLevel,
 	PiHoleAccessoryConfig,
@@ -132,7 +133,7 @@ class PiholeSwitch implements AccessoryPlugin {
 				responseType: "json",
 			});
 			if (this.logLevel >= LogLevel.INFO) {
-				this.log.info(JSON.stringify(response));
+				this.log.info(stringify(response));
 			}
 			return response.data;
 		} catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import {
 } from "homebridge";
 
 import axios, { AxiosResponse } from "axios";
-import { stringify } from "flatted";
 import {
 	LogLevel,
 	PiHoleAccessoryConfig,
@@ -133,7 +132,13 @@ class PiholeSwitch implements AccessoryPlugin {
 				responseType: "json",
 			});
 			if (this.logLevel >= LogLevel.INFO) {
-				this.log.info(stringify(response));
+				this.log.info(JSON.stringify({
+					data: response.data,
+					status: response.status,
+					statusText: response.statusText,
+					headers: response.headers,
+					request: response.config,
+				}));
 			}
 			return response.data;
 		} catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import {
 	Service,
 } from "homebridge";
 
-import * as http from "http";
 import axios, { AxiosResponse } from "axios";
 import {
 	LogLevel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,10 +67,10 @@ class PiholeSwitch implements AccessoryPlugin {
 
 		this.switchService = new hap.Service.Switch(this.name);
 		this.switchService.getCharacteristic(hap.Characteristic.On)
-			.on(CharacteristicEventTypes.GET, (next: CharacteristicGetCallback) => {
-				this._makeRequest(STATUS_URL, next);
+			.on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+				this._makeRequest(STATUS_URL, callback);
 			})
-			.on(CharacteristicEventTypes.SET, (value: CharacteristicValue, next: CharacteristicSetCallback) => {
+			.on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
 				let queryString: any = {};
 				let switchState = value as boolean;
 
@@ -82,7 +82,7 @@ class PiholeSwitch implements AccessoryPlugin {
 
 				queryString[AUTH_URL] = this.auth;
 
-				this._makeRequest(stringify(queryString), next);
+				this._makeRequest(stringify(queryString), callback);
 			});
 	}
 
@@ -93,7 +93,7 @@ class PiholeSwitch implements AccessoryPlugin {
 		];
 	}
 
-	private _responseHandler(response: http.IncomingMessage, next: Function) {
+	private _responseHandler(response: http.IncomingMessage, callback: Function) {
 		let body = "";
 
 		response.on("data", (data) => {
@@ -109,26 +109,26 @@ class PiholeSwitch implements AccessoryPlugin {
 				let jsonBody = JSON.parse(body);
 
 				if (jsonBody && jsonBody.status) {
-					next(undefined, jsonBody.status == "enabled");
+					callback(undefined, jsonBody.status == "enabled");
 				} else {
-					next({});
+					callback({});
 				}
 			} catch (e) {
 				if (this.logLevel >= 1) {
 					this.log.error(e);
 				}
 
-				next(e);
+				callback(e);
 			}
 		});
 	}
 
-	private _makeRequest(path: string, next: Function) {
+	private _makeRequest(path: string, callback: Function) {
 		let request = http.get({
 			host: this.host,
 			port: this.port,
 			path: `${this.baseDirectory}${BASE_URL}?${path}`
-		}, (response) => this._responseHandler(response, next));
+		}, (response) => this._responseHandler(response, callback));
 
 		request.on("error", (error) => {
 			if (this.logLevel >= 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import {
 	Service
 } from "homebridge";
 
-import * as http from "http";
 import axios, { AxiosResponse } from "axios";
 import { LogLevel, PiHoleAccessoryConfig, PiHoleRequest, PiHoleStatusRequest, PiHoleEnableRequest, PiHoleDisableRequest, PiHoleStatusResponse } from "./types";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,40 +1,42 @@
-import {
-	AccessoryConfig
-} from "homebridge";
+import { AccessoryConfig } from "homebridge";
 
 export enum LogLevel {
 	DISABLED = 0,
 	ERROR = 1,
 	INFO = 2,
-};
+}
 
 export interface PiHoleAccessoryConfig extends AccessoryConfig {
-	manufacturer ?: string;
-	model ?: string;
-	"serial-number" ?: string;
-	auth ?: string;
-	ssl ?: boolean;
-	host ?: string;
-	baseDirectory ?: string;
-	time ?: number;
-	port ?: number;
-	logLevel ?: LogLevel;
+	"manufacturer"?: string;
+	"model"?: string;
+	"serial-number"?: string;
+	"auth"?: string;
+	"ssl"?: boolean;
+	"host"?: string;
+	"baseDirectory"?: string;
+	"time"?: number;
+	"port"?: number;
+	"logLevel"?: LogLevel;
+}
 
-};
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface PiHoleRequest {}
 
-export type PiHoleRequest<Endpoint extends string> = {
-	[key in Endpoint]: any; // usually a "1" or current time, argument does not matter
-};
-
-export type PiHoleAuthenticatedRequest<Endpoint extends string> = PiHoleRequest<Endpoint> & {
-	auth: string
-};
+export interface PiHoleAuthenticatedRequest extends PiHoleRequest {
+	auth: string;
+}
 
 // from https://discourse.pi-hole.net/t/pi-hole-api/1863
-export type PiHoleStatusRequest = PiHoleRequest<"status">;
-export type PiHoleEnableRequest = PiHoleAuthenticatedRequest<"enable">;
-export type PiHoleDisableRequest = PiHoleAuthenticatedRequest<"disable">;
+export interface PiHoleStatusRequest extends PiHoleRequest {
+	status: number;
+}
+export interface PiHoleEnableRequest extends PiHoleAuthenticatedRequest {
+	enable: number;
+}
+export interface PiHoleDisableRequest extends PiHoleAuthenticatedRequest {
+	disable: number; // number of seconds
+}
 
-export type PiHoleStatusResponse = {
+export interface PiHoleStatusResponse {
 	status: "disabled" | "enabled";
-};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export type PiHoleRequest<Endpoint extends string> = {
 	[key in Endpoint]: any; // usually a "1" or current time, argument does not matter
 };
 
-export type PiHoleAuthenticatedRequest<Endpoint> = PiHoleRequest<Endpoint> & {
+export type PiHoleAuthenticatedRequest<Endpoint extends string> = PiHoleRequest<Endpoint> & {
 	auth: string
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,40 @@
+import {
+	AccessoryConfig
+} from "homebridge";
+
+export enum LogLevel {
+	DISABLED = 0,
+	ERROR = 1,
+	INFO = 2,
+};
+
+export interface PiHoleAccessoryConfig extends AccessoryConfig {
+	manufacturer ?: string;
+	model ?: string;
+	"serial-number" ?: string;
+	auth ?: string;
+	ssl ?: boolean;
+	host ?: string;
+	baseDirectory ?: string;
+	time ?: number;
+	port ?: number;
+	logLevel ?: LogLevel;
+
+};
+
+export type PiHoleRequest<Endpoint extends string> = {
+	[key in Endpoint]: any; // usually a "1" or current time, argument does not matter
+};
+
+export type PiHoleAuthenticatedRequest<Endpoint> = PiHoleRequest<Endpoint> & {
+	auth: string
+};
+
+// from https://discourse.pi-hole.net/t/pi-hole-api/1863
+export type PiHoleStatusRequest = PiHoleRequest<"status">;
+export type PiHoleEnableRequest = PiHoleAuthenticatedRequest<"enable">;
+export type PiHoleDisableRequest = PiHoleAuthenticatedRequest<"disable">;
+
+export type PiHoleStatusResponse = {
+	status: "disabled" | "enabled";
+};


### PR DESCRIPTION
Me (and I would imagine _some_ others) use Pi-hole on a multipurpose server and, as such, already have existing HTTP services running.  Therefore, instead of using Pi-hole's builtin server, they would configure it within their existing configuration.  This extra variable allows people to configure this (for example, I use `/pi-hole/` as `/admin/` was already in use and applies to much more than just Pi-hole).

Additionally, my local HTTP server enforces HTTPS (through redirects).  Therefore, I'm also working on adding HTTPS/redirect support. (Closes #15 )

This should not break any existing configurations.