### PR TITLE
Use the main API endpoint for status rather than the status only one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,7 @@ class PiholeSwitch implements AccessoryPlugin {
 
 					callback(undefined, oldValue);
 
-					const { status } = await this._makeRequest<PiHoleStatusRequest, PiHoleStatusResponse>({
-						status: 1,
-					});
+					const { status } = await this._makeRequest<PiHoleRequest, PiHoleStatusResponse>({});
 
 					this.switchService
 						.getCharacteristic(hap.Characteristic.On)


### PR DESCRIPTION
Work around the bug in Pihole where the status only API always returns disabled